### PR TITLE
Add lobby restart flow and cumulative leaderboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,9 +120,13 @@
     <!-- View: Results -->
     <section id="viewResults" class="card hidden">
       <h2 class="text-lg font-semibold">Results — Room <span id="roomCodeLabelResults"></span></h2>
-      <ol id="leaderboard" class="mt-3 bg-white border rounded divide-y"></ol>
+      <h3 class="font-medium mt-3">This Game</h3>
+      <ol id="leaderboardGame" class="mt-1 bg-white border rounded divide-y"></ol>
+      <h3 class="font-medium mt-4">Overall</h3>
+      <ol id="leaderboardOverall" class="mt-1 bg-white border rounded divide-y"></ol>
       <div class="mt-4 flex flex-wrap gap-3">
-        <button id="playAgainBtn" class="btn">Back to Lobby</button>
+        <button id="backToLobbyBtn" class="btn">Back to Lobby</button>
+        <button id="restartGameBtn" class="btn hidden">Restart Game</button>
         <button id="newRoomBtn" class="btn-secondary">Create New Room</button>
       </div>
     </section>
@@ -143,7 +147,7 @@
     </dialog>
   </main>
 
-  <footer class="py-8 text-center text-xs text-slate-500">Built by ChatGPT • Supabase Realtime channels</footer>
+  <!-- Footer intentionally left blank -->
 
   <!-- Libs -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>


### PR DESCRIPTION
## Summary
- remove footer branding
- allow host to return players to lobby or restart the game
- track cumulative player scores and display both per-game and overall leaderboards

## Testing
- `node --check js/app_supabase_tf_guestflow.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9e52140c832c9ed18852d34bacb6